### PR TITLE
Update LocalResponseNormalization.java

### DIFF
--- a/CNNdroid Source Package/java/layers/LocalResponseNormalization.java
+++ b/CNNdroid Source Package/java/layers/LocalResponseNormalization.java
@@ -132,7 +132,7 @@ public class LocalResponseNormalization implements LayerInterface {
                     int thread;
                     for (thread = 0; thread < threadCount ; thread++)
                         if (!threads[thread].done)
-                            break;
+                            continue;
                     if (thread == threadCount)
                         break;
                     try {


### PR DESCRIPTION
If any thread does not finish working, the loop should not be stopped.